### PR TITLE
More reliable setters

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 Nick Benoit
+Copyright (c) 2022 Atomic Jolt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/legacy_encryption_adapter.gemspec
+++ b/legacy_encryption_adapter.gemspec
@@ -3,7 +3,7 @@ require_relative 'lib/legacy_encryption_adapter/version'
 Gem::Specification.new do |spec|
   spec.name          = "legacy_encryption_adapter"
   spec.version       = LegacyEncryptionAdapter::VERSION
-  spec.authors       = ["Nick Benoit"]
+  spec.authors       = ["Atomic Jolt"]
   spec.email         = ["nick.benoit@atomicjolt.com"]
 
   spec.summary       = "summary"

--- a/lib/legacy_encryption_adapter.rb
+++ b/lib/legacy_encryption_adapter.rb
@@ -54,11 +54,17 @@ module LegacyEncryptionAdapter
                             true
                           end
 
-      # When we write set both rails 7 encrypted field and legacy field
-      if should_use_legacy == true 
+      begin
         legacy_encryption_adapter_attr_encrypted_encrypt(property_name, property_value)
+      rescue StandardError => e
+        Rails.logger.error('Error setting legacy encrypted fields', e)
       end
-      non_legacy_behavior.call
+
+      begin
+        non_legacy_behavior.call
+      rescue StandardError => e
+        Rails.logger.error('Error setting new encrypted fields', e)
+      end
     end
   end
 


### PR DESCRIPTION
* Continue to set legacy field even after we use new field
* Rescue around both setters so if one fails the other can still work 


Fixes: https://www.pivotaltracker.com/story/show/182765608